### PR TITLE
Notify Match Fixtures/Results via telegram bot

### DIFF
--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -101,6 +101,11 @@ class DataUpdateCommand extends ContainerAwareCommand
             $this->getContainer()->get('app.slack')->setText($msgText)->post();
 
             $logText = $logText . "\n" . $msgText . "\n";
+            $botToken = "your_bot_token";
+            $website = "https://api.telegram.org/bot" . $botToken;
+            $channelId = "@your_channel_id";
+            $url = $website."/sendmessage?chat_id=".$channelId."&text=".urlencode($logText);
+            file_get_contents($url);
         } else {
             $logText = $logText . "\n" . 'No fixtures/results added or updated.' . "\n";
         }

--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -101,11 +101,13 @@ class DataUpdateCommand extends ContainerAwareCommand
             $this->getContainer()->get('app.slack')->setText($msgText)->post();
 
             $logText = $logText . "\n" . $msgText . "\n";
-            $botToken = "your_bot_token";
-            $website = "https://api.telegram.org/bot" . $botToken;
-            $channelId = "@your_channel_id";
-            $url = $website."/sendmessage?chat_id=".$channelId."&text=".urlencode($logText);
-            file_get_contents($url);
+            if (0) {
+                $botToken = "your_bot_token";
+                $website = "https://api.telegram.org/bot" . $botToken;
+                $channelId = "@your_channel_id";
+                $url = $website."/sendmessage?chat_id=".$channelId."&text=".urlencode($logText);
+                file_get_contents($url);
+            }
         } else {
             $logText = $logText . "\n" . 'No fixtures/results added or updated.' . "\n";
         }


### PR DESCRIPTION
I thought it's a good way to notify users via a channel when an update has done on matches or results, all you should do is to create a telegram bot, add it to your channel and edit code to your channel and bot ID.